### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ operator to
 "(2+3)(6+4)".keval() == "(2+3)*(6+4)".keval()
 ```
 
+In addition the symbols `(`,`)`,`,` are reserved and trying to create operator using one of those symbols will result with an exception.
+
 ## Error Handling
 
 In case of an error, Keval will throw one of several `KevalException`s:

--- a/src/commonMain/kotlin/com/notkamui/keval/AbstractSyntaxTree.kt
+++ b/src/commonMain/kotlin/com/notkamui/keval/AbstractSyntaxTree.kt
@@ -3,7 +3,7 @@ package com.notkamui.keval
 /**
  * Represents an operator, may be either a binary operator, or a function
  */
-internal sealed interface KevalOperator
+sealed interface KevalOperator
 
 /**
  * Represents a binary operator

--- a/src/commonMain/kotlin/com/notkamui/keval/Keval.kt
+++ b/src/commonMain/kotlin/com/notkamui/keval/Keval.kt
@@ -102,13 +102,12 @@ constructor(
     fun eval(
         mathExpression: String,
     ): Double {
-        // The tokenizer assumes multiplication, hence disallowing overriding `*` operator
-        val operators = kevalDSL.resources
-            .plus("*" to KevalBinaryOperator(3, true) { a, b -> a * b })
 
+        val operators = resourcesView()
         return mathExpression.toAbstractSyntaxTree(operators).eval()
     }
 
+    // The tokenizer assumes multiplication, hence disallowing overriding `*` operator
     fun resourcesView(): Map<String, KevalOperator> = kevalDSL.resources
         .plus("*" to KevalBinaryOperator(3, true) { a, b -> a * b })
 

--- a/src/commonMain/kotlin/com/notkamui/keval/Keval.kt
+++ b/src/commonMain/kotlin/com/notkamui/keval/Keval.kt
@@ -109,6 +109,9 @@ constructor(
         return mathExpression.toAbstractSyntaxTree(operators).eval()
     }
 
+    fun resourcesView(): Map<String, KevalOperator> = kevalDSL.resources
+        .plus("*" to KevalBinaryOperator(3, true) { a, b -> a * b })
+
     companion object {
         /**
          * Evaluates [mathExpression] from a [String] and returns a [Double] value with the default resources.

--- a/src/commonMain/kotlin/com/notkamui/keval/KevalDSL.kt
+++ b/src/commonMain/kotlin/com/notkamui/keval/KevalDSL.kt
@@ -36,7 +36,7 @@ class KevalDSL internal constructor() {
             throw KevalDSLException("a symbol must NOT be a letter, a digit, an underscore, parentheses nor a comma but was: $symbol")
         }
         if (symbol == '*') {
-            throw KevalDSLException("* cannot be overwrite")
+            throw KevalDSLException("* cannot be overwritten")
         }
         val implementation = op.implementation ?: throw KevalDSLException("implementation is not set")
         val precedence = op.precedence ?: throw KevalDSLException("precedence is not set")

--- a/src/commonMain/kotlin/com/notkamui/keval/KevalDSL.kt
+++ b/src/commonMain/kotlin/com/notkamui/keval/KevalDSL.kt
@@ -32,8 +32,11 @@ class KevalDSL internal constructor() {
 
         // checking if every field has been properly defined
         val symbol = op.symbol ?: throw KevalDSLException("symbol is not set")
-        if (symbol.isLetterOrDigit() || symbol == '_') {
-            throw KevalDSLException("a symbol must NOT be a letter, nor a digit, nor an underscore: $symbol")
+        if (symbol.isLetterOrDigit() || symbol in listOf('_', '(', ')', ',')) {
+            throw KevalDSLException("a symbol must NOT be a letter, a digit, an underscore, parentheses nor a comma but was: $symbol")
+        }
+        if (symbol == '*') {
+            throw KevalDSLException("* cannot be overwrite")
         }
         val implementation = op.implementation ?: throw KevalDSLException("implementation is not set")
         val precedence = op.precedence ?: throw KevalDSLException("precedence is not set")

--- a/src/commonMain/kotlin/com/notkamui/keval/KevalException.kt
+++ b/src/commonMain/kotlin/com/notkamui/keval/KevalException.kt
@@ -15,8 +15,13 @@ sealed class KevalException(message: String) : Exception(message)
  */
 open class KevalInvalidExpressionException internal constructor(
     val expression: String,
-    val position: Int
-) : KevalException("Invalid expression at $position in $expression")
+    val position: Int,
+    extraMessage: String = ""
+) : KevalException(
+    "Invalid expression at position $position in $expression${
+        if (extraMessage.isNotBlank()) ", $extraMessage" else ""
+    }"
+)
 
 /**
  * Invalid Operator Exception, is thrown when an invalid/unknown operator is found
@@ -28,8 +33,9 @@ open class KevalInvalidExpressionException internal constructor(
 class KevalInvalidSymbolException internal constructor(
     val invalidSymbol: String,
     expression: String,
-    position: Int
-) : KevalInvalidExpressionException(expression, position)
+    position: Int,
+    message: String = ""
+) : KevalInvalidExpressionException(expression, position, message)
 
 /**
  * Zero Division Exception, is thrown when a zero division occurs (i.e. x/0, x%0)

--- a/src/commonMain/kotlin/com/notkamui/keval/ShuntingYard.kt
+++ b/src/commonMain/kotlin/com/notkamui/keval/ShuntingYard.kt
@@ -130,7 +130,7 @@ internal fun String.toAbstractSyntaxTree(operators: Map<String, KevalOperator>):
 
     val outputQueue = mutableListOf<Node>()
     val operatorStack = mutableListOf<String>()
-    val tokens = this.tokenize(operators.keys)
+    val tokens = this.tokenize(operators)
     val tokensToString = tokens.joinToString("")
     var currentPos = 0
 

--- a/src/commonMain/kotlin/com/notkamui/keval/Tokenizer.kt
+++ b/src/commonMain/kotlin/com/notkamui/keval/Tokenizer.kt
@@ -37,7 +37,7 @@ private fun List<String>.normalizeTokens(symbols: Map<String, KevalOperator>, to
             token == "(" -> TokenType.LPAREN
                 .also {
                     parenthesesCount += 1
-                    // add `(` whenever the parentheses are closing a function call
+                    // add `(` whenever the parentheses are opening a function call
                     if (functionAtCount.last() == parenthesesCount) ret.add("(")
                     if (shouldAssumeMul(prevToken)) ret.add("*")
                     ret.add(token)

--- a/src/commonMain/kotlin/com/notkamui/keval/Tokenizer.kt
+++ b/src/commonMain/kotlin/com/notkamui/keval/Tokenizer.kt
@@ -12,25 +12,62 @@ private enum class TokenType {
 private fun shouldAssumeMul(tokenType: TokenType): Boolean =
     tokenType == TokenType.OPERAND || tokenType == TokenType.RPAREN
 
-// This function add product symbols where they should be assumed
-private fun List<String>.assumeMul(symbolsSet: Set<String>, tokensToString: String): List<String> {
+// normalize tokens to be of specific form (add product symbols where they should be assumed and enclose every parameter of a function in parentheses)
+private fun List<String>.normalizeTokens(symbols: Map<String, KevalOperator>, tokensToString: String): List<String> {
     var currentPos = 0
     var prevToken = TokenType.FIRST
+    var parenthesesCount = 0
+    val functionAtCount = mutableListOf(-1)
     val ret = mutableListOf<String>()
     this.forEach { token ->
         prevToken = when {
             token.isNumeric() -> TokenType.OPERAND.also {
                 if (shouldAssumeMul(prevToken)) ret.add("*")
+                ret.add(token)
             }
-            token.isKevalOperator(symbolsSet) -> TokenType.OPERATOR
-            token == "(" -> TokenType.LPAREN.also {
-                if (shouldAssumeMul(prevToken)) ret.add("*")
-            }
+
+            token.isKevalOperator(symbols.keys) -> TokenType.OPERATOR
+                .also {
+                    ret.add(token)
+                    if (symbols[token] is KevalFunction) {
+                        functionAtCount.add(parenthesesCount + 1)
+                    }
+                }
+
+            token == "(" -> TokenType.LPAREN
+                .also {
+                    parenthesesCount += 1
+                    // add `(` whenever the parentheses are closing a function call
+                    if (functionAtCount.last() == parenthesesCount) ret.add("(")
+                    if (shouldAssumeMul(prevToken)) ret.add("*")
+                    ret.add(token)
+                }
+
             token == ")" -> TokenType.RPAREN
+                .also {
+                    // add `)` whenever the parentheses are closing a function call
+                    if (functionAtCount.last() == parenthesesCount) {
+                        ret.add(")")
+                        functionAtCount.removeLast()
+                    }
+                    parenthesesCount -= 1
+                    ret.add(token)
+                }
+
             token == "," -> TokenType.COMMA
+                .also {
+                    // transform `,` into `),(` whenever `,` is a separator or parameters in functions
+                    if (functionAtCount.last() == parenthesesCount) {
+                        ret.add(")")
+                        ret.add(token)
+                        ret.add("(")
+                    } else {
+                        throw KevalInvalidSymbolException(token, tokensToString, currentPos, "comma can only be used in the context of a function")
+                    }
+                }
+
             else -> throw KevalInvalidSymbolException(token, tokensToString, currentPos)
         }
-        ret.add(token)
         currentPos += token.length
     }
     return ret
@@ -62,7 +99,7 @@ internal fun String.isKevalOperator(symbolsSet: Set<String>): Boolean = this in 
  * @return the list of tokens
  * @throws KevalInvalidSymbolException if the expression contains an invalid symbol
  */
-internal fun String.tokenize(symbolsSet: Set<String>): List<String> {
+internal fun String.tokenize(symbolsSet: Map<String, KevalOperator>): List<String> {
     val limits = """ |[^a-zA-Z0-9._]|,|\(|\)"""
     val tokens = this
         .split("""(?<=($limits))|(?=($limits))""".toRegex()) // tokenizing
@@ -71,5 +108,5 @@ internal fun String.tokenize(symbolsSet: Set<String>): List<String> {
 
     val tokensToString = tokens.joinToString("")
 
-    return tokens.assumeMul(symbolsSet, tokensToString)
+    return tokens.normalizeTokens(symbolsSet, tokensToString)
 }

--- a/src/commonTest/kotlin/com/notkamui/keval/DSLResourcesTests.kt
+++ b/src/commonTest/kotlin/com/notkamui/keval/DSLResourcesTests.kt
@@ -198,7 +198,6 @@ class DLSTest {
                 implementation = { args -> args[0] }
             }
         }
-        assertEquals(1.0, k.eval("f((1),())"), "f((1),())")
         assertEquals(1.0, k.eval("f(((1)))"), "f(((1)))")
     }
 }

--- a/src/commonTest/kotlin/com/notkamui/keval/DSLResourcesTests.kt
+++ b/src/commonTest/kotlin/com/notkamui/keval/DSLResourcesTests.kt
@@ -144,23 +144,33 @@ class DLSTest {
 
     @Test
     fun checkOrder() {
-        val first = 1.0
-        val second = 2.0
-        val third = 3.0
         val k = Keval {
             includeDefault()
             function {
-                name = "test"
+                name = "first"
                 arity = 3
                 implementation = { args ->
-                    assertEquals(args[0], first)
-                    assertEquals(args[1], second)
-                    assertEquals(args[2], third)
-                    .0
+                    args[0]
+                }
+            }
+            function {
+                name = "second"
+                arity = 3
+                implementation = { args ->
+                    args[1]
+                }
+            }
+            function {
+                name = "third"
+                arity = 3
+                implementation = { args ->
+                    args[2]
                 }
             }
         }
-        k.eval("test(1, 2, 3)")
+        assertEquals(1.0, k.eval("first(1, 2, 3)"), "first(1, 2, 3)")
+        assertEquals(2.0, k.eval("second(1, 2, 3)"), "second(1, 2, 3)")
+        assertEquals(3.0, k.eval("third(1, 2, 3)"), "third(1, 2, 3)")
     }
 
     @Test
@@ -173,7 +183,22 @@ class DLSTest {
                 implementation = { args -> if (args[0] != .0) args[1] else args[2] }
             }
         }
-        assertEquals(4.0, k.eval("if((1*1), 4, 5)"))
-        assertEquals(4.0, k.eval("if(1*1, 4, 5)"))
+
+        assertEquals(4.0, k.eval("if((1*1), 4, 5)"), "if((1*1), 4, 5)")
+        assertEquals(4.0, k.eval("if(1*1, 4, 5)"), "if(1*1, 4, 5)")
+    }
+
+    @Test
+    fun checkRepeatingParentheses() {
+        val k = Keval {
+            includeDefault()
+            function {
+                name = "f"
+                arity = 1
+                implementation = { args -> args[0] }
+            }
+        }
+        assertEquals(1.0, k.eval("f((1),())"), "f((1),())")
+        assertEquals(1.0, k.eval("f(((1)))"), "f(((1)))")
     }
 }

--- a/src/commonTest/kotlin/com/notkamui/keval/TokenizerTest.kt
+++ b/src/commonTest/kotlin/com/notkamui/keval/TokenizerTest.kt
@@ -91,7 +91,7 @@ class TokenizerTest {
             }
         }
 
-        val nodes = "f(1,)".tokenize(k.resourcesView())
+        val nodes = "f(((1)))".tokenize(k.resourcesView())
         assertEquals("f((((1))))", nodes.joinToString(separator = ""))
     }
 }


### PR DESCRIPTION
Solved the problem of expressions inside function parameters not count well by counting parentheses and automatically wrapping parameters of a function with extra layer of parentheses (e.g. `if(1*1,4,5)` -> `if((1*1),(4),(5))`  and `if((1*1),4,5)` -> `if(((1*1)),(4),(5))`)