### PR TITLE
Add support for Apple targets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,19 @@ kotlin {
     linuxX64()
     mingwX64()
 
+    macosX64()
+    macosArm64()
+    iosSimulatorArm64()
+    iosX64()
+    iosArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+
     sourceSets {
         val commonMain by getting {
         }


### PR DESCRIPTION
I kept the changes to a minimum to make the review process as simple as possible.  
Initially, I also updated the Kotlin multiplatform plugin and Gradle because my installed JDK was incompatible with Gradle 7.6 (which is currently used by the project). However, this is a different issue not related to adding support for Apple targets.